### PR TITLE
mongo db repository 도입 & 연동

### DIFF
--- a/src/main/kotlin/com/debaters/debateOnServer/SpringConfig.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/SpringConfig.kt
@@ -1,7 +1,14 @@
 package com.debaters.debateOnServer
 
+import com.mongodb.ConnectionString
+import com.mongodb.MongoClientSettings
+import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoClients
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories
 import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
@@ -10,7 +17,6 @@ import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.security.web.server.authentication.AuthenticationWebFilter
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint
-
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.reactive.CorsWebFilter
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
@@ -60,5 +66,26 @@ class SpringConfig {
         source.registerCorsConfiguration("/**", config)
 
         return CorsWebFilter(source)
+    }
+}
+
+@Configuration
+@EnableMongoRepositories(basePackages = ["com.debaters.debateOnServer.repositories"])
+class DBConfig : AbstractMongoClientConfiguration() {
+
+    @Value("\${spring.data.mongodb.uri}")
+    lateinit var mongoUri: String
+
+    override fun getDatabaseName(): String {
+        return "debates"
+    }
+
+    override fun mongoClient(): MongoClient {
+        val connectionString = ConnectionString(mongoUri)
+        val mongoClientSettings = MongoClientSettings.builder()
+                .applyConnectionString(connectionString)
+                .build()
+
+        return MongoClients.create(mongoClientSettings)
     }
 }

--- a/src/main/kotlin/com/debaters/debateOnServer/models/Debate.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/models/Debate.kt
@@ -1,16 +1,18 @@
 package com.debaters.debateOnServer.models
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 import org.springframework.stereotype.Component
 
 @Document("debate")
 data class Debate(
-    val debateId: String,
-    @GraphQLDescription("토론의 제목입니다.")
-    val title: String,
-    @GraphQLDescription("토론의 설명입니다. 50자를 넘어가지 않습니다.")
-    val description: String,
-    val creatorName: String,
-    val creatorId: String,
+        @Id
+        val id: String = "",
+        @GraphQLDescription("토론의 제목입니다.")
+        val title: String,
+        @GraphQLDescription("토론의 설명입니다. 50자를 넘어가지 않습니다.")
+        val description: String,
+        val creatorName: String,
+        val creatorId: String,
 )

--- a/src/main/kotlin/com/debaters/debateOnServer/repositories/DebatesRepository.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/repositories/DebatesRepository.kt
@@ -1,0 +1,16 @@
+package com.debaters.debateOnServer.repositories
+
+import com.debaters.debateOnServer.models.Debate
+import org.springframework.context.annotation.Bean
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Component
+import java.util.*
+
+/**
+ * 토론 목록을 조회 가능한 repository
+ */
+@Component
+interface DebatesRepository : PagingAndSortingRepository<Debate, String>

--- a/src/main/kotlin/com/debaters/debateOnServer/service/DebateService.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/service/DebateService.kt
@@ -1,63 +1,27 @@
 package com.debaters.debateOnServer.service
 
 import com.debaters.debateOnServer.models.Debate
+import com.debaters.debateOnServer.repositories.DebatesRepository
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.core.MongoTemplate
-import org.springframework.data.mongodb.core.insert
-import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 
 
 @Service
 class DebateService {
-    @ExperimentalStdlibApi
-    private val mockList = buildList {
-        repeat(30) {
-            addAll(
-                    listOf(
-                            Debate(
-                                    debateId = "${it * 4 + 0}",
-                                    title = "짜장면은 찍먹이냐 부먹이냐",
-                                    description = "논란의 정점을 찍어보도록 해요",
-                                    creatorName = "zimin",
-                                    creatorId = "a",
-                            ),
-                            Debate(
-                                    debateId = "${it * 4 + 1}",
-                                    title = "백신은 화이지/아스트라제네카",
-                                    description = "백신은 잘 골라야 해 ",
-                                    creatorName = "zimin",
-                                    creatorId = "a",
-                            ),
-                            Debate(
-                                    debateId = "${it * 4 + 2}",
-                                    title = "iOS/Android",
-                                    description = "What's your favorite mobile os?",
-                                    creatorName = "zimin",
-                                    creatorId = "a",
-                            ),
-                            Debate(
-                                    debateId = "${it * 4 + 3}",
-                                    title = "Windows/Max",
-                                    description = "What's your favorite OS?",
-                                    creatorName = "zimin",
-                                    creatorId = "a",
-                            ),
-                    )
-            )
-        }
-    }.toMutableList()
+
+    @Autowired
+    private lateinit var repository: DebatesRepository
 
     /**
      * 현재 mock 데이터를 리턴함.
      */
     @ExperimentalStdlibApi
     suspend fun getDebates(offset: Int = 0, size: Int = 10): List<Debate> {
-        return mockList.subList(offset, offset + size)
+        return repository.findAll(PageRequest.of(offset, size)).toList()
     }
-
-    @Autowired
-    private lateinit var mongoTemplate: MongoTemplate
 
     @ExperimentalStdlibApi
     suspend fun createDebate(
@@ -65,13 +29,23 @@ class DebateService {
             description: String,
             creatorName: String,
     ): Boolean {
-        val debate = Debate("1L", "제목", "메세지", "카카오택원", "1L")
-        println(mongoTemplate.insert(debate))
-        return true
+        val debate = Debate(
+                title = title,
+                description = description,
+                creatorName = creatorName,
+                creatorId = "abc"
+        )
+
+        return try {
+            repository.save(debate)
+            true
+        } catch (ex: Exception) {
+            false
+        }
     }
 
     @ExperimentalStdlibApi
     suspend fun findDebate(id: String): Debate? {
-        return mockList.find { it.debateId == id }
+        return repository.findById(id).get()
     }
 }

--- a/src/test/kotlin/com/debaters/debateOnServer/DebateRepositoryTests.kt
+++ b/src/test/kotlin/com/debaters/debateOnServer/DebateRepositoryTests.kt
@@ -1,0 +1,23 @@
+package com.debaters.debateOnServer
+
+import com.debaters.debateOnServer.repositories.DebatesRepository
+import org.junit.jupiter.api.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.SpringRunner
+
+@RunWith(SpringRunner::class)
+@ContextConfiguration
+class DebateRepositoryTests {
+
+    @Autowired
+    lateinit var repository: DebatesRepository
+
+    @Test
+    fun readFirstPage() {
+        val debates = repository.findAll(PageRequest.of(0, 10))
+        assert(debates.isFirst)
+    }
+}


### PR DESCRIPTION
* mongo db repository를 사용하기 위한 설정 추가. configuration을 추가해서 db 설정을 코드에서 수행하도록 변경했습니다
* debate관련 api들이 실제 데이터와 연동되는지 확인했습니다.
* 더이상 사용하지 않는 template은 제거
* debate 클래스에서 id 값의 이름은 debateId -> Id 로 변경