### PR TITLE
댓글 기능 api 추가

### DIFF
--- a/src/main/kotlin/com/debaters/debateOnServer/DebatesComponent.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/DebatesComponent.kt
@@ -1,5 +1,8 @@
 package com.debaters.debateOnServer
+
+import com.debaters.debateOnServer.models.Comment
 import com.debaters.debateOnServer.models.Debate
+import com.debaters.debateOnServer.service.CommentService
 import com.debaters.debateOnServer.service.DebateService
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.server.operations.Mutation
@@ -30,6 +33,9 @@ class DebateMutation : Mutation {
     @Autowired
     lateinit var debateService: DebateService
 
+    @Autowired
+    lateinit var commentService: CommentService
+
     suspend fun createDebate(
             @GraphQLDescription("토론의 제목입니다. 50자를 넘어가지 않습니다.")
             title: String,
@@ -43,5 +49,14 @@ class DebateMutation : Mutation {
                 description,
                 creatorName,
         )
+    }
+
+    suspend fun addComment(
+            @GraphQLDescription("댓글을 추가할 Debate 의 id")
+            debateId: String,
+            @GraphQLDescription("추가할 댓글 정보")
+            comment: Comment,
+    ) : Boolean {
+        return commentService.writeComment(debateId, comment)
     }
 }

--- a/src/main/kotlin/com/debaters/debateOnServer/models/Comment.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/models/Comment.kt
@@ -1,0 +1,13 @@
+package com.debaters.debateOnServer.models
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+
+/**
+ * 토론 하나에 추가되는 댓글을 표현
+ */
+data class Comment(
+        @GraphQLDescription("댓글 내용")
+        val content: String,
+        @GraphQLDescription("작성자 이름")
+        val writerName: String,
+)

--- a/src/main/kotlin/com/debaters/debateOnServer/models/Debate.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/models/Debate.kt
@@ -15,4 +15,5 @@ data class Debate(
         val description: String,
         val creatorName: String,
         val creatorId: String,
+        val comments: MutableList<Comment> = mutableListOf()
 )

--- a/src/main/kotlin/com/debaters/debateOnServer/service/CommentService.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/service/CommentService.kt
@@ -1,0 +1,20 @@
+package com.debaters.debateOnServer.service
+
+import com.debaters.debateOnServer.models.Comment
+import com.debaters.debateOnServer.repositories.DebatesRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class CommentService {
+
+    @Autowired
+    private lateinit var debateRepository: DebatesRepository
+
+    suspend fun writeComment(debateId: String, comment: Comment): Boolean {
+        val debate = debateRepository.findById(debateId).get()
+        debate.comments.add(comment)
+        debateRepository.save(debate)
+        return true
+    }
+}


### PR DESCRIPTION
* addComment를 통해 특정 토론에 댓글을 추가 가능
* comment에 대한 조회는 기존에 있던 debate api를 통해 가능함 (ql필드로 추가)