### PR TITLE
Sentry 연동 추가 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,8 @@ dependencies {
 	implementation("com.expediagroup", "graphql-kotlin-spring-server", "4.1.1")
 	implementation("io.jsonwebtoken:jjwt-api:0.11.1")
 
-
+	implementation("io.sentry:sentry-spring-boot-starter:5.5.2")
+	implementation("io.sentry:sentry-logback:5.5.2")
 
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.1")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.1")

--- a/src/main/kotlin/com/debaters/debateOnServer/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/GlobalExceptionHandler.kt
@@ -1,0 +1,13 @@
+package com.debaters.debateOnServer
+
+import graphql.execution.DataFetcherExceptionHandlerParameters
+import graphql.execution.DataFetcherExceptionHandlerResult
+import graphql.execution.SimpleDataFetcherExceptionHandler
+import io.sentry.Sentry
+
+class GlobalExceptionHandler : SimpleDataFetcherExceptionHandler() {
+    override fun onException(handlerParameters: DataFetcherExceptionHandlerParameters?): DataFetcherExceptionHandlerResult {
+        Sentry.captureException(handlerParameters?.exception ?: IllegalStateException("unhandled error"))
+        return super.onException(handlerParameters)
+    }
+}

--- a/src/main/kotlin/com/debaters/debateOnServer/SpringConfig.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/SpringConfig.kt
@@ -4,6 +4,7 @@ import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
 import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
+import graphql.execution.DataFetcherExceptionHandler
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -66,6 +67,11 @@ class SpringConfig {
         source.registerCorsConfiguration("/**", config)
 
         return CorsWebFilter(source)
+    }
+
+    @Bean
+    fun dataFetchExceptionHandler(): DataFetcherExceptionHandler {
+        return GlobalExceptionHandler()
     }
 }
 


### PR DESCRIPTION
https://docs.sentry.io 
서버 상태 모니터링을 위한 툴을 연동. 

처리 되지 않은 예외가 있다면 모두 여기로~ 일반적인 spring exeptionhandler로는 전역으로 잡을 수가 없고, 지금 graph ql 이 올라가 있어서 그에 해당하는 방법으로 잡아야 함. 이미 bean 으로 SimpleDataFeatcherExeptionHandler 가 있어서 이를 갈아끼울 수 있도록 함. (@config 에서 오버라이딩)