### PR TITLE
댓글 api 수정 

### DIFF
--- a/src/main/kotlin/com/debaters/debateOnServer/DebatesComponent.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/DebatesComponent.kt
@@ -23,6 +23,9 @@ class DebatesQuery : Query {
     lateinit var debateService: DebateService
 
     @Autowired
+    lateinit var commentService: CommentService
+
+    @Autowired
     lateinit var nicknameService: NicknameService
 
     fun titles() = listOf("korean and japan", "new idea")
@@ -30,6 +33,9 @@ class DebatesQuery : Query {
     fun members() = listOf("김", "김", "오",  "최", "변")
     fun submarine() = listOf("잠수함패치의 증거")
     fun contact() = "010-1111-1111"
+
+    suspend fun getComments(debateId: String, offset: Int, size: Int) =
+            commentService.getComments(debateId, offset, size)
 
     suspend fun homeDebates(offset: Int = 0, size: Int = 10) = debateService.getDebates(offset, size)
 

--- a/src/main/kotlin/com/debaters/debateOnServer/models/Comment.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/models/Comment.kt
@@ -1,11 +1,17 @@
 package com.debaters.debateOnServer.models
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import org.springframework.data.annotation.QueryAnnotation
+import org.springframework.data.mongodb.core.mapping.Document
 
 /**
  * 토론 하나에 추가되는 댓글을 표현
+ * Mongo db에 저장하는 모델. 추후 저장하는 모델, api 리턴 타입 분리해볼 것.
  */
+@Document
 data class Comment(
+        @GraphQLDescription("이 댓글이 적힌 debate 의 id")
+        val debateId: String,
         @GraphQLDescription("댓글 내용")
         val content: String,
         @GraphQLDescription("작성자 이름")

--- a/src/main/kotlin/com/debaters/debateOnServer/models/Debate.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/models/Debate.kt
@@ -28,5 +28,4 @@ data class Debate(
         val createdTimestamp: OffsetDateTime = OffsetDateTime.now(),
         @GraphQLDescription("마지막으로 변경된 시간입니다. 댓글이 업데이트 되어도 변경됩니다.")
         val updatedTimestamp: OffsetDateTime = OffsetDateTime.now(),
-        val comments: MutableList<Comment> = mutableListOf()
 )

--- a/src/main/kotlin/com/debaters/debateOnServer/repositories/CommentsRepository.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/repositories/CommentsRepository.kt
@@ -1,0 +1,11 @@
+package com.debaters.debateOnServer.repositories
+
+import com.debaters.debateOnServer.models.Comment
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Component
+
+@Component
+interface CommentsRepository : MongoRepository<Comment, String> {
+    // 요것은 queryDsl 의 매직. 처음안것이라 주석 추가
+    fun findAllByDebateId(debateId: String): List<Comment>
+}

--- a/src/main/kotlin/com/debaters/debateOnServer/service/CommentService.kt
+++ b/src/main/kotlin/com/debaters/debateOnServer/service/CommentService.kt
@@ -1,25 +1,33 @@
 package com.debaters.debateOnServer.service
 
 import com.debaters.debateOnServer.models.Comment
+import com.debaters.debateOnServer.models.Debate
+import com.debaters.debateOnServer.repositories.CommentsRepository
 import com.debaters.debateOnServer.repositories.DebatesRepository
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Example
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 
+private const val DEFAULT_PAGE_SIZE = 10
+
 @Service
 class CommentService {
 
     @Autowired
-    private lateinit var debateRepository: DebatesRepository
+    private lateinit var commentsRepository: CommentsRepository
+
+    @ExperimentalStdlibApi
+    suspend fun getComments(debateId: String, offset: Int = 0, size: Int = DEFAULT_PAGE_SIZE): List<Comment> {
+        return commentsRepository.findAllByDebateId(debateId).subList(offset, offset + size)
+    }
 
     suspend fun writeComment(debateId: String, comment: Comment): Boolean {
-        val debate = debateRepository.findById(debateId).get()
-        debate.comments.add(comment)
-        val newDebate = debate.copy(updatedTimestamp = OffsetDateTime.now())
-        debateRepository.save(newDebate)
+        commentsRepository.save(comment.copy(debateId = debateId))
         return true
     }
 }


### PR DESCRIPTION
* 댓글 api 가 수정되어, debate에서 필드로 가져오는것이 아니라 별도 api 로 호출해야 함.
* 내부적으로도 원래는 debate 안에 comment 를 저장했는데, mongo db 데이터 모델링 부분을 참고하여 comment는 별도의 collection으로 존재하도록 한다음 debate의 id를 받아서 처리합니다.
* 